### PR TITLE
(PUP-2790) Use telinit to detect upstart version.

### DIFF
--- a/lib/puppet/provider/service/upstart.rb
+++ b/lib/puppet/provider/service/upstart.rb
@@ -22,7 +22,8 @@ Puppet::Type.type(:service).provide :upstart, :parent => :debian do
            :stop    => "/sbin/stop",
            :restart => "/sbin/restart",
            :status_exec  => "/sbin/status",
-           :initctl => "/sbin/initctl"
+           :initctl => "/sbin/initctl",
+           :telinit => "/sbin/telinit"
 
   # upstart developer haven't implemented initctl enable/disable yet:
   # http://www.linuxplanet.com/linuxplanet/tutorials/7033/2/
@@ -72,7 +73,7 @@ Puppet::Type.type(:service).provide :upstart, :parent => :debian do
   end
 
   def upstart_version
-    @upstart_version ||= initctl("--version").match(/initctl \(upstart ([^\)]*)\)/)[1]
+    @upstart_version ||= telinit("--version").match(/telinit \(upstart ([^\)]*)\)/)[1]
   end
 
   # Where is our override script?

--- a/spec/unit/provider/service/upstart_spec.rb
+++ b/spec/unit/provider/service/upstart_spec.rb
@@ -111,6 +111,16 @@ describe Puppet::Type.type(:service).provider(:upstart) do
     end
   end
 
+  describe "#upstart_version" do
+    it "should call telinit --version" do
+      resource = Puppet::Type.type(:service).new(:name => "foo", :provider => :upstart)
+      provider = provider_class.new(resource)
+      provider.expects(:telinit).with('--version').returns(
+          'telinit (upstart 0.9.1)')
+      expect(provider.upstart_version).to eql('0.9.1')
+    end
+  end
+
   describe "inheritance" do
     let :resource do
       resource = Puppet::Type.type(:service).new(:name => "foo", :provider => :upstart)


### PR DESCRIPTION
During installations, initctl is overridden by a script that does nothing except displaying a message. This makes the original provider misbehave when forced to be used. telinit is not diverted and provides the same version information.
Still, for anything but version information, start/stop/restart etc. should remain the same, as it is actually not wanted to start a service during this stage of installation.
